### PR TITLE
feat: Add content script with inline tooltip UI

### DIFF
--- a/content.css
+++ b/content.css
@@ -1,0 +1,126 @@
+#ai-detector-tooltip {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+#ai-detector-tooltip .ai-detector-content {
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  color: #fff;
+  border-radius: 12px;
+  padding: 16px;
+  min-width: 220px;
+  max-width: 260px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+#ai-detector-tooltip .ai-detector-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+#ai-detector-tooltip .ai-detector-title {
+  font-weight: 600;
+  color: #00d9ff;
+}
+
+#ai-detector-tooltip .ai-detector-close {
+  background: none;
+  border: none;
+  color: #a0a0a0;
+  font-size: 20px;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+#ai-detector-tooltip .ai-detector-close:hover {
+  color: #fff;
+}
+
+#ai-detector-tooltip .ai-detector-score {
+  text-align: center;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  margin-bottom: 12px;
+}
+
+#ai-detector-tooltip .ai-detector-score .score-number {
+  display: block;
+  font-size: 32px;
+  font-weight: bold;
+}
+
+#ai-detector-tooltip .ai-detector-score .score-label {
+  display: block;
+  font-size: 12px;
+  color: #a0a0a0;
+  margin-top: 4px;
+}
+
+#ai-detector-tooltip .ai-detector-score.ai .score-number {
+  color: #ff5252;
+}
+
+#ai-detector-tooltip .ai-detector-score.human .score-number {
+  color: #4caf50;
+}
+
+#ai-detector-tooltip .ai-detector-score.mixed .score-number {
+  color: #ffc107;
+}
+
+#ai-detector-tooltip .ai-detector-verdict {
+  text-align: center;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-weight: 600;
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+
+#ai-detector-tooltip .ai-detector-verdict.ai {
+  background: rgba(255, 82, 82, 0.2);
+  color: #ff5252;
+}
+
+#ai-detector-tooltip .ai-detector-verdict.human {
+  background: rgba(76, 175, 80, 0.2);
+  color: #4caf50;
+}
+
+#ai-detector-tooltip .ai-detector-verdict.mixed {
+  background: rgba(255, 193, 7, 0.2);
+  color: #ffc107;
+}
+
+#ai-detector-tooltip .ai-detector-stats {
+  text-align: center;
+  font-size: 12px;
+  color: #a0a0a0;
+}
+
+#ai-detector-tooltip .ai-detector-error {
+  color: #ff5252;
+  text-align: center;
+}
+
+#ai-detector-tooltip .ai-detector-spinner {
+  width: 30px;
+  height: 30px;
+  border: 3px solid rgba(0, 217, 255, 0.2);
+  border-top-color: #00d9ff;
+  border-radius: 50%;
+  margin: 0 auto 12px;
+  animation: ai-detector-spin 1s linear infinite;
+}
+
+@keyframes ai-detector-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/content.js
+++ b/content.js
@@ -1,0 +1,120 @@
+// Content script for AI Text Detector
+(function() {
+  let tooltip = null;
+
+  // Listen for messages from background script
+  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.action === 'getSelectedText') {
+      const selectedText = window.getSelection().toString().trim();
+      sendResponse({ text: selectedText });
+    } else if (request.action === 'showTooltip') {
+      showAnalysisTooltip(request.data);
+    } else if (request.action === 'showLoading') {
+      showLoadingTooltip();
+    } else if (request.action === 'showError') {
+      showErrorTooltip(request.message);
+    }
+    return true;
+  });
+
+  function createTooltipBase() {
+    removeTooltip();
+
+    tooltip = document.createElement('div');
+    tooltip.id = 'ai-detector-tooltip';
+
+    // Position near selection
+    const selection = window.getSelection();
+    if (selection.rangeCount > 0) {
+      const range = selection.getRangeAt(0);
+      const rect = range.getBoundingClientRect();
+
+      tooltip.style.position = 'fixed';
+      tooltip.style.left = `${Math.min(rect.left, window.innerWidth - 280)}px`;
+      tooltip.style.top = `${rect.bottom + 10}px`;
+      tooltip.style.zIndex = '2147483647';
+    }
+
+    document.body.appendChild(tooltip);
+    return tooltip;
+  }
+
+  function showLoadingTooltip() {
+    const tip = createTooltipBase();
+    tip.innerHTML = `
+      <div class="ai-detector-content">
+        <div class="ai-detector-spinner"></div>
+        <p>Analyzing text...</p>
+      </div>
+    `;
+  }
+
+  function showAnalysisTooltip(data) {
+    const tip = createTooltipBase();
+    const score = Math.round(data.aiScore * 100);
+
+    let verdictClass, verdictText;
+    if (score >= 70) {
+      verdictClass = 'ai';
+      verdictText = 'Likely AI-Generated';
+    } else if (score >= 40) {
+      verdictClass = 'mixed';
+      verdictText = 'Mixed / Uncertain';
+    } else {
+      verdictClass = 'human';
+      verdictText = 'Likely Human-Written';
+    }
+
+    tip.innerHTML = `
+      <div class="ai-detector-content">
+        <div class="ai-detector-header">
+          <span class="ai-detector-title">AI Detection Result</span>
+          <button class="ai-detector-close">&times;</button>
+        </div>
+        <div class="ai-detector-score ${verdictClass}">
+          <span class="score-number">${score}%</span>
+          <span class="score-label">AI Probability</span>
+        </div>
+        <div class="ai-detector-verdict ${verdictClass}">${verdictText}</div>
+        <div class="ai-detector-stats">
+          <span>${data.wordCount} words analyzed</span>
+        </div>
+      </div>
+    `;
+
+    // Add close button handler
+    tip.querySelector('.ai-detector-close').addEventListener('click', removeTooltip);
+
+    // Auto-remove after 10 seconds
+    setTimeout(removeTooltip, 10000);
+  }
+
+  function showErrorTooltip(message) {
+    const tip = createTooltipBase();
+    tip.innerHTML = `
+      <div class="ai-detector-content">
+        <div class="ai-detector-header">
+          <span class="ai-detector-title">Error</span>
+          <button class="ai-detector-close">&times;</button>
+        </div>
+        <p class="ai-detector-error">${message}</p>
+      </div>
+    `;
+
+    tip.querySelector('.ai-detector-close').addEventListener('click', removeTooltip);
+  }
+
+  function removeTooltip() {
+    if (tooltip && tooltip.parentNode) {
+      tooltip.parentNode.removeChild(tooltip);
+      tooltip = null;
+    }
+  }
+
+  // Remove tooltip when clicking elsewhere
+  document.addEventListener('click', (e) => {
+    if (tooltip && !tooltip.contains(e.target)) {
+      removeTooltip();
+    }
+  });
+})();


### PR DESCRIPTION
## Summary

This PR adds the content script that provides real-time visual feedback directly on webpages when analyzing text.

- **Inline Tooltips**: Display analysis results near the selected text without leaving context
- **Three UI States**: Loading spinner, result display, and error messages
- **Polished UX**: Auto-hide, click-outside dismiss, smooth animations

## Features

### Tooltip States
| State | Description |
|-------|-------------|
| Loading | Animated spinner while API request is in progress |
| Result | Score percentage + color-coded verdict (red/yellow/green) + word count |
| Error | Error message with manual close button |

### Technical Implementation
- Content script injected on all pages via manifest
- Receives messages from background service worker
- Creates DOM elements dynamically for tooltips
- Uses `position: fixed` with calculated coordinates near selection
- Z-index `2147483647` ensures visibility over any page content

## Screenshots

The tooltip appears near selected text showing:
- Percentage score (0-100%)
- Verdict: "Likely AI-Generated" / "Mixed/Uncertain" / "Likely Human-Written"
- Word count of analyzed text

## Test Plan

- [ ] Select text on various websites (news, blogs, social media)
- [ ] Verify tooltip appears near selection
- [ ] Check loading spinner displays during analysis
- [ ] Confirm results show with correct color coding
- [ ] Test auto-hide after 10 seconds
- [ ] Verify click-outside dismisses tooltip
- [ ] Test error state with invalid API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)